### PR TITLE
Implemented crashing fix from #85

### DIFF
--- a/crates/transform-gizmo-bevy/src/render.rs
+++ b/crates/transform-gizmo-bevy/src/render.rs
@@ -192,6 +192,10 @@ impl<P: PhaseItem> RenderCommand<P> for DrawTransformGizmo {
             return RenderCommandResult::Failure("No GizmoDrawDataHandle inner found");
         };
 
+        if gizmo.index_buffer.size() == 0 {
+            return RenderCommandResult::Failure("gizmo.index_buffer is empty");
+        }
+
         pass.set_index_buffer(gizmo.index_buffer.slice(..), 0, IndexFormat::Uint32);
         pass.set_vertex_buffer(0, gizmo.position_buffer.slice(..));
         pass.set_vertex_buffer(1, gizmo.color_buffer.slice(..));


### PR DESCRIPTION
( Link: https://github.com/urholaukkarinen/transform-gizmo/pull/85#issuecomment-2549984428 )
I was able to repro this exact issue on Windows 10 22H2 (seems to be a Windows-only bug judging by the fact that you weren't able to reproduce it) and added the fix for it. Could you please test if this causes any problems on Linux and add this commit to the PR?